### PR TITLE
Fix CI

### DIFF
--- a/Gruntfile.coffee
+++ b/Gruntfile.coffee
@@ -25,7 +25,7 @@ module.exports = (grunt) ->
 
     shell:
       test:
-        command: 'node --harmony_collections node_modules/.bin/jasmine-focused --coffee --captureExceptions --forceexit spec'
+        command: 'node node_modules/.bin/jasmine-focused --coffee --captureExceptions --forceexit spec'
         options:
           stdout: true
           stderr: true


### PR DESCRIPTION
Requires #1 

This PR removes the outdated, and no longer supported NodeJS flag `--harmony-collections` which enabled (at the time) experimental JavaScript features, which are now standards in the language.